### PR TITLE
feat: add static study app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Hawker 400 Study App
+
+Aplicativo web estático para estudo do Hawker 400. Funciona em qualquer navegador moderno abrindo o `index.html` diretamente (sem servidor) e roda offline após o primeiro carregamento.
+
+## Como abrir
+1. Coloque `index.html`, `styles.css`, `app.js` e um arquivo `data.json` na mesma pasta.
+2. Abra o arquivo `index.html` no navegador.
+3. Todo o progresso fica salvo no `localStorage` do navegador.
+
+## Dados (data.json)
+- Substitua o `data.json` pelo novo arquivo ou use **Importar JSON** na aba **Conteúdo** para fazer merge dos dados.
+- O arquivo deve seguir este formato:
+
+```json
+{
+  "memory": [],
+  "flash": [
+    { "id": "fc-0001", "front": "Pergunta", "back": "Resposta" }
+  ]
+}
+```
+
+## Flashcards e revisão espaçada
+- A aba **Flashcards** usa o algoritmo SM-2 simplificado.
+- Após ver a frente, clique em **Mostrar resposta** e depois em **Difícil**, **Ok** ou **Fácil**.
+- Os cartões são reexibidos com base no intervalo calculado: respostas mais fáceis aumentam o intervalo; difíceis voltam mais cedo.
+
+## Memory Items
+- A aba **Memory Items** apresenta um cenário por vez.
+- Clique nos passos na ordem correta para montar a sequência.
+- Use **Checar** para ver o resultado, **Refazer** para tentar novamente ou **Próximo** para outro cenário.
+- Um timer opcional (definido em Config) reduz pontos se o tempo acabar.
+
+## Conteúdo
+- **Exportar JSON** baixa todo o conteúdo atual (sem progresso de estudo).
+- **Importar JSON** permite adicionar/atualizar cartões.
+- **Limpar progresso** zera apenas os dados de revisão espaçada e pontuações.
+
+## Config
+- Ajuste o tempo do jogo de Memory Items e a meta diária de flashcards.
+- Clique em **Salvar** para gravar no navegador.
+
+## Privacidade
+Todo o conteúdo e progresso ficam apenas no seu navegador. Nenhuma informação é enviada a servidores.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,341 @@
+// storage
+const STORE_KEY = 'hc-store';
+const SRS_KEY = 'hc-srs';
+const CFG_KEY = 'hc-cfg';
+const MEM_KEY = 'hc-memory-stats';
+
+function load(key) {
+  try {
+    return JSON.parse(localStorage.getItem(key));
+  } catch (e) {
+    return null;
+  }
+}
+
+function save(key, value) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+// global state
+let appData = { flash: [], memory: [] };
+let srsData = load(SRS_KEY) || {};
+let memoryStats = load(MEM_KEY) || {};
+let config = load(CFG_KEY) || { memoryTime: 90, dailyGoal: 20 };
+
+// initialization
+document.addEventListener('DOMContentLoaded', init);
+
+function init() {
+  setupNav();
+  loadData().then(() => {
+    updateHome();
+    setupFlashcards();
+    setupMemory();
+    updateContentPreview();
+    loadConfigUI();
+  });
+  setupContent();
+  setupConfig();
+}
+
+// navigation
+function setupNav() {
+  document.querySelectorAll('.tab-btn').forEach((btn) => {
+    btn.addEventListener('click', () => showTab(btn.dataset.tab));
+  });
+  document.getElementById('start-flash').addEventListener('click', () => {
+    showTab('flash');
+    startFlashcards();
+  });
+  document.getElementById('start-memory').addEventListener('click', () => {
+    showTab('memory');
+    startMemory();
+  });
+}
+
+function showTab(id) {
+  document.querySelectorAll('.tab-section').forEach((sec) => sec.classList.add('hidden'));
+  const tab = document.getElementById(id);
+  if (tab) tab.classList.remove('hidden');
+}
+
+// data loading
+async function loadData() {
+  const stored = load(STORE_KEY);
+  if (stored) appData = stored;
+  try {
+    const resp = await fetch('data.json');
+    if (resp.ok) {
+      const json = await resp.json();
+      appData = json;
+      save(STORE_KEY, json);
+    }
+  } catch (e) {
+    console.log('fetch failed');
+  }
+  if (!appData || !Array.isArray(appData.flash) || !Array.isArray(appData.memory)) {
+    appData = stored || { flash: [], memory: [] };
+  }
+}
+
+function updateHome() {
+  document.getElementById('stats').textContent = `Flashcards: ${appData.flash.length} | Memory: ${appData.memory.length}`;
+  const msg = document.getElementById('home-msg');
+  if (appData.flash.length === 0 && appData.memory.length === 0) {
+    msg.textContent = 'Dados não carregados. Use "Importar JSON" na aba Conteúdo.';
+  } else {
+    msg.textContent = '';
+    if (appData.flash.length === 0) msg.textContent = 'Sem cartões no momento.';
+  }
+}
+
+// Flashcards (SRS)
+let flashQueue = [];
+let flashIndex = 0;
+
+function setupFlashcards() {
+  document.getElementById('show-answer').addEventListener('click', showAnswer);
+  document.querySelectorAll('.rate-btn').forEach((btn) => {
+    btn.addEventListener('click', () => rateCard(parseInt(btn.dataset.rate)));
+  });
+}
+
+function startFlashcards() {
+  if (appData.flash.length === 0) {
+    document.getElementById('flash-empty').classList.remove('hidden');
+    return;
+  }
+  document.getElementById('flash-empty').classList.add('hidden');
+  buildFlashQueue();
+  flashIndex = 0;
+  showFlashcard();
+}
+
+function buildFlashQueue() {
+  const today = Date.now();
+  const due = [];
+  const rest = [];
+  for (const card of appData.flash) {
+    const st = srsData[card.id] || { reps: 0, interval: 1, ef: 2.5, due: 0 };
+    card._state = st;
+    if (st.due <= today) due.push(card); else rest.push(card);
+  }
+  shuffle(rest);
+  flashQueue = due.concat(rest);
+}
+
+function showFlashcard() {
+  const front = document.getElementById('flash-front');
+  const back = document.getElementById('flash-back');
+  const showBtn = document.getElementById('show-answer');
+  const actions = document.getElementById('flash-actions');
+  const counter = document.getElementById('flash-counter');
+  if (flashIndex >= flashQueue.length) {
+    front.textContent = 'Fim!';
+    back.textContent = '';
+    showBtn.classList.add('hidden');
+    actions.classList.add('hidden');
+    counter.textContent = '';
+    return;
+  }
+  const card = flashQueue[flashIndex];
+  front.textContent = card.front;
+  back.textContent = card.back;
+  back.classList.add('hidden');
+  showBtn.classList.remove('hidden');
+  actions.classList.add('hidden');
+  counter.textContent = `Restantes: ${flashQueue.length - flashIndex}`;
+}
+
+function showAnswer() {
+  document.getElementById('flash-back').classList.remove('hidden');
+  document.getElementById('show-answer').classList.add('hidden');
+  document.getElementById('flash-actions').classList.remove('hidden');
+}
+
+function rateCard(q) {
+  const card = flashQueue[flashIndex];
+  const st = card._state;
+  if (q < 3) {
+    st.reps = 0;
+    st.interval = 1;
+  } else {
+    st.ef = Math.max(1.3, st.ef + (0.1 - (5 - q) * (0.08 + (5 - q) * 0.02)));
+    if (st.reps === 0) st.interval = 1;
+    else if (st.reps === 1) st.interval = 6;
+    else st.interval = Math.round(st.interval * st.ef);
+    st.reps++;
+  }
+  st.due = Date.now() + st.interval * 24 * 60 * 60 * 1000;
+  srsData[card.id] = st;
+  save(SRS_KEY, srsData);
+  flashIndex++;
+  showFlashcard();
+}
+
+// Memory Items
+let memoryIndex = 0;
+let memoryTimer = null;
+let timeLeft = config.memoryTime;
+let seq = [];
+
+function setupMemory() {
+  document.getElementById('memory-check').addEventListener('click', checkMemory);
+  document.getElementById('memory-reset').addEventListener('click', startMemory);
+  document.getElementById('memory-next').addEventListener('click', () => {
+    memoryIndex = (memoryIndex + 1) % (appData.memory.length || 1);
+    startMemory();
+  });
+}
+
+function startMemory() {
+  if (appData.memory.length === 0) {
+    document.getElementById('memory-empty').classList.remove('hidden');
+    document.getElementById('memory-game').classList.add('hidden');
+    return;
+  }
+  document.getElementById('memory-empty').classList.add('hidden');
+  document.getElementById('memory-game').classList.remove('hidden');
+  const item = appData.memory[memoryIndex];
+  document.getElementById('memory-title').textContent = item.title;
+  const options = (item.steps || []).concat(item.distractors || []);
+  shuffle(options);
+  const optDiv = document.getElementById('memory-options');
+  optDiv.innerHTML = '';
+  seq = [];
+  options.forEach((step) => {
+    const b = document.createElement('button');
+    b.textContent = step;
+    b.addEventListener('click', () => {
+      b.disabled = true;
+      seq.push(step);
+      renderSequence();
+    });
+    optDiv.appendChild(b);
+  });
+  document.getElementById('memory-feedback').textContent = '';
+  timeLeft = config.memoryTime;
+  updateTimer();
+  if (memoryTimer) clearInterval(memoryTimer);
+  memoryTimer = setInterval(() => {
+    timeLeft--;
+    updateTimer();
+    if (timeLeft <= 0) {
+      clearInterval(memoryTimer);
+      checkMemory();
+    }
+  }, 1000);
+}
+
+function renderSequence() {
+  document.getElementById('memory-sequence').textContent = seq.join(' \u203a ');
+}
+
+function checkMemory() {
+  const item = appData.memory[memoryIndex];
+  const correct = item.steps || [];
+  let score = 0;
+  const missing = [];
+  for (let i = 0; i < correct.length; i++) {
+    if (seq[i] === correct[i]) score += 10; else missing.push(correct[i]);
+  }
+  if (missing.length === 0 && seq.length === correct.length) score += 10;
+  document.getElementById('memory-feedback').textContent = missing.length === 0 ? `Perfeito! ${score} pts` : `Faltou: ${missing.join(', ')} (${score} pts)`;
+  memoryStats[item.id] = score;
+  save(MEM_KEY, memoryStats);
+}
+
+function updateTimer() {
+  document.getElementById('memory-timer').textContent = secondsToMMSS(timeLeft);
+}
+
+// Conteúdo (import/export)
+function setupContent() {
+  document.getElementById('export-json').addEventListener('click', () => {
+    const blob = new Blob([JSON.stringify(appData, null, 2)], { type: 'application/json' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = 'export.json';
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+  document.getElementById('import-json').addEventListener('change', handleImport);
+  document.getElementById('clear-progress').addEventListener('click', () => {
+    if (confirm('Limpar progresso?')) {
+      localStorage.removeItem(SRS_KEY);
+      localStorage.removeItem(MEM_KEY);
+      srsData = {};
+      memoryStats = {};
+      alert('Progresso limpo.');
+    }
+  });
+}
+
+function handleImport(evt) {
+  const file = evt.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const json = JSON.parse(reader.result);
+      mergeData(json);
+      save(STORE_KEY, appData);
+      updateHome();
+      updateContentPreview();
+      startFlashcards();
+      startMemory();
+    } catch (e) {
+      alert('JSON inválido');
+    }
+  };
+  reader.readAsText(file);
+  evt.target.value = '';
+}
+
+function mergeData(newData) {
+  if (newData.flash) {
+    const byId = Object.fromEntries(appData.flash.map((c) => [c.id, c]));
+    newData.flash.forEach((c) => { byId[c.id] = c; });
+    appData.flash = Object.values(byId);
+  }
+  if (newData.memory) {
+    const byId = Object.fromEntries(appData.memory.map((c) => [c.id, c]));
+    newData.memory.forEach((c) => { byId[c.id] = c; });
+    appData.memory = Object.values(byId);
+  }
+}
+
+function updateContentPreview() {
+  document.getElementById('content-preview').textContent = JSON.stringify(appData, null, 2);
+}
+
+// Config
+function setupConfig() {
+  document.getElementById('config-form').addEventListener('submit', (e) => {
+    e.preventDefault();
+    config.memoryTime = parseInt(document.getElementById('cfg-memory-time').value, 10) || 90;
+    config.dailyGoal = parseInt(document.getElementById('cfg-daily-goal').value, 10) || 20;
+    save(CFG_KEY, config);
+    document.getElementById('config-msg').textContent = 'Salvo!';
+    setTimeout(() => (document.getElementById('config-msg').textContent = ''), 2000);
+  });
+}
+
+function loadConfigUI() {
+  document.getElementById('cfg-memory-time').value = config.memoryTime;
+  document.getElementById('cfg-daily-goal').value = config.dailyGoal;
+}
+
+// helpers
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+function secondsToMMSS(s) {
+  const m = String(Math.floor(s / 60)).padStart(2, '0');
+  const sec = String(s % 60).padStart(2, '0');
+  return `${m}:${sec}`;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hawker 400 Study</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Hawker 400 Study</h1>
+    <nav>
+      <button class="tab-btn" data-tab="home" aria-label="Início">Início</button>
+      <button class="tab-btn" data-tab="flash" aria-label="Flashcards">Flashcards</button>
+      <button class="tab-btn" data-tab="memory" aria-label="Memory Items">Memory Items</button>
+      <button class="tab-btn" data-tab="content" aria-label="Conteúdo">Conteúdo</button>
+      <button class="tab-btn" data-tab="config" aria-label="Config">Config</button>
+    </nav>
+  </header>
+
+  <main>
+    <section id="home" class="tab-section">
+      <div class="actions">
+        <button id="start-flash">Começar Flashcards</button>
+        <button id="start-memory">Treinar Memory Items</button>
+      </div>
+      <div id="stats"></div>
+      <div id="home-msg" class="msg"></div>
+    </section>
+
+    <section id="flash" class="tab-section hidden">
+      <div id="flashcard">
+        <div id="flash-front"></div>
+        <div id="flash-back" class="hidden"></div>
+      </div>
+      <button id="show-answer">Mostrar resposta</button>
+      <div id="flash-actions" class="hidden">
+        <button class="rate-btn" data-rate="2">Difícil</button>
+        <button class="rate-btn" data-rate="3">Ok</button>
+        <button class="rate-btn" data-rate="5">Fácil</button>
+      </div>
+      <div id="flash-counter"></div>
+      <div id="flash-empty" class="msg hidden">Sem cartões no momento.</div>
+    </section>
+
+    <section id="memory" class="tab-section hidden">
+      <div id="memory-empty" class="msg hidden">Sem itens ainda.</div>
+      <div id="memory-game">
+        <h2 id="memory-title"></h2>
+        <div id="memory-options" class="grid"></div>
+        <div id="memory-sequence"></div>
+        <div id="memory-feedback" class="msg"></div>
+        <div id="memory-timer"></div>
+        <div class="memory-buttons">
+          <button id="memory-check">Checar</button>
+          <button id="memory-reset">Refazer</button>
+          <button id="memory-next">Próximo</button>
+        </div>
+      </div>
+    </section>
+
+    <section id="content" class="tab-section hidden">
+      <pre id="content-preview"></pre>
+      <div class="content-actions">
+        <button id="export-json">Exportar JSON</button>
+        <label class="import-label">
+          Importar JSON
+          <input type="file" id="import-json" accept="application/json" hidden>
+        </label>
+        <button id="clear-progress">Limpar progresso</button>
+      </div>
+    </section>
+
+    <section id="config" class="tab-section hidden">
+      <form id="config-form">
+        <label>
+          Tempo do Memory (segundos)
+          <input type="number" id="cfg-memory-time" min="10" step="5">
+        </label>
+        <label>
+          Meta diária de flashcards
+          <input type="number" id="cfg-daily-goal" min="1" step="1">
+        </label>
+        <button type="submit">Salvar</button>
+        <div id="config-msg" class="msg"></div>
+      </form>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,135 @@
+:root {
+  --bg: #121212;
+  --fg: #eee;
+  --accent: #0d6efd;
+  --danger: #dc3545;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+header {
+  background: #1e1e1e;
+  padding: 0.5rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 1.2rem;
+  text-align: center;
+}
+
+nav {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 0.5rem;
+}
+
+nav button {
+  background: none;
+  border: none;
+  color: var(--fg);
+  padding: 0.5rem;
+  cursor: pointer;
+}
+
+nav button:focus {
+  outline: 2px solid var(--accent);
+}
+
+.tab-section {
+  padding: 1rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.actions button,
+.memory-buttons button,
+#show-answer,
+#flash-actions button,
+.content-actions button,
+.import-label {
+  display: block;
+  width: 100%;
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background: var(--accent);
+  border: none;
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.memory-buttons button {
+  width: auto;
+  display: inline-block;
+}
+
+#import-json {
+  display: none;
+}
+
+.import-label {
+  text-align: center;
+  cursor: pointer;
+}
+
+#flashcard {
+  min-height: 100px;
+  padding: 1rem;
+  border: 1px solid #333;
+  margin-bottom: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.grid button {
+  padding: 0.5rem;
+}
+
+#memory-sequence {
+  min-height: 2rem;
+  margin-top: 0.5rem;
+}
+
+.msg {
+  margin-top: 0.5rem;
+  color: var(--accent);
+}
+
+.rate-btn[data-rate="2"] {
+  background: var(--danger);
+}
+
+.rate-btn[data-rate="3"] {
+  background: #ffc107;
+  color: #000;
+}
+
+.rate-btn[data-rate="5"] {
+  background: #198754;
+}
+
+@media (min-width: 600px) {
+  nav button {
+    font-size: 1rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- build offline single-page app with tabs for flashcards, memory items, content and config
- implement SM-2 spaced repetition, memory sequence game and JSON import/export
- add dark, mobile-first styling and README instructions

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689b75cca548832f98e56c5f49f83340