### PR TITLE
Add prototype Hawker 400 Trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Hawker 400 Trainer
+
+Aplicativo web estático para estudo de flash cards e memory items do Hawker/Beechjet 400/400A.
+
+## Como usar
+1. Abra `index.html` no navegador.
+2. Selecione o modo desejado em **Treino**: Flash Cards ou Memory Items.
+3. Para alterar tempo por pergunta ou tolerância numérica, acesse a aba **Config**.
+
+## Banco de dados
+Os dados estão em `data/hawker400.json`. Troque ou acrescente questões editando esse arquivo. Mantenha o esquema:
+
+```json
+{
+  "flash": [ { "id": "...", "front": "...", "back": "...", "tags": [], "source": {...} } ],
+  "memory": [ { "id": "...", "title": "...", "steps": ["..."], "tags": [], "source": {...} } ]
+}
+```
+
+## Firebase (opcional)
+O modo online ainda não está implementado. Para futuras integrações, adicione a configuração Firebase em `app.js` no objeto `firebaseConfig`.
+
+## Offline
+Todos os arquivos são estáticos; basta abrir `index.html` para funcionar offline.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,162 @@
+// Simple Hawker 400 Trainer logic
+const state = {
+    data: null,
+    currentFlash: null,
+    currentMemory: null,
+    settings: {
+        time: parseInt(localStorage.getItem('time') || '20', 10),
+        tolerance: parseInt(localStorage.getItem('tolerance') || '1', 10)
+    }
+};
+
+async function loadData() {
+    const res = await fetch('data/hawker400.json');
+    state.data = await res.json();
+    populateDatabase();
+}
+
+function switchTab(id) {
+    document.querySelectorAll('nav button').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.tab === id);
+    });
+    document.querySelectorAll('main .tab').forEach(sec => {
+        sec.classList.toggle('hidden', sec.id !== id);
+    });
+}
+
+// Tab buttons
+ document.querySelectorAll('nav button').forEach(btn => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+ });
+
+// Config
+ document.getElementById('cfg-time').value = state.settings.time;
+ document.getElementById('cfg-tolerance').value = state.settings.tolerance;
+ document.getElementById('cfg-save').addEventListener('click', () => {
+    state.settings.time = parseInt(document.getElementById('cfg-time').value, 10);
+    state.settings.tolerance = parseInt(document.getElementById('cfg-tolerance').value, 10);
+    localStorage.setItem('time', state.settings.time);
+    localStorage.setItem('tolerance', state.settings.tolerance);
+    alert('Configurações salvas');
+ });
+
+// Flash cards
+ document.getElementById('start-flash').addEventListener('click', () => {
+    document.getElementById('memory-area').classList.add('hidden');
+    document.getElementById('flash-area').classList.remove('hidden');
+    nextFlash();
+ });
+
+ function nextFlash() {
+    const pool = state.data.flash;
+    state.currentFlash = pool[Math.floor(Math.random() * pool.length)];
+    document.getElementById('flash-question').textContent = state.currentFlash.front;
+    document.getElementById('flash-answer').value = '';
+    document.getElementById('flash-feedback').textContent = '';
+ }
+
+ function normalizeAnswer(ans) {
+    return ans.trim().toUpperCase().replace(/KTS|KIAS|KT|KTS GS|KTS GROUND SPEED|KTS\.?/g, 'KIAS');
+ }
+
+ document.getElementById('flash-submit').addEventListener('click', () => {
+    const user = normalizeAnswer(document.getElementById('flash-answer').value);
+    const correct = normalizeAnswer(state.currentFlash.back);
+    let feedback = 'Errado';
+
+    if (user === correct) {
+        feedback = 'Correto';
+    } else {
+        // numeric tolerance
+        const numUser = parseFloat(user);
+        const numCorrect = parseFloat(correct);
+        if (!isNaN(numUser) && !isNaN(numCorrect)) {
+            const diff = Math.abs(numUser - numCorrect);
+            if (diff <= state.settings.tolerance) feedback = 'Parcial';
+        }
+    }
+    document.getElementById('flash-feedback').textContent = feedback;
+ });
+ document.getElementById('flash-reveal').addEventListener('click', () => {
+    document.getElementById('flash-feedback').textContent = state.currentFlash.back;
+ });
+
+// Memory items
+ document.getElementById('start-memory').addEventListener('click', () => {
+    document.getElementById('flash-area').classList.add('hidden');
+    document.getElementById('memory-area').classList.remove('hidden');
+    nextMemory();
+ });
+
+ function nextMemory() {
+    const pool = state.data.memory;
+    state.currentMemory = pool[Math.floor(Math.random() * pool.length)];
+    document.getElementById('memory-title').textContent = state.currentMemory.title;
+    const list = document.getElementById('memory-list');
+    list.innerHTML = '';
+    const steps = [...state.currentMemory.steps];
+    shuffleArray(steps);
+    steps.forEach((step, idx) => {
+        const li = document.createElement('li');
+        li.textContent = step;
+        li.draggable = true;
+        li.dataset.index = idx;
+        list.appendChild(li);
+    });
+ }
+
+ function shuffleArray(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+ }
+
+ let dragSrcEl = null;
+ document.getElementById('memory-list').addEventListener('dragstart', e => {
+    dragSrcEl = e.target;
+ });
+ document.getElementById('memory-list').addEventListener('dragover', e => {
+    e.preventDefault();
+ });
+ document.getElementById('memory-list').addEventListener('drop', e => {
+    e.preventDefault();
+    if (dragSrcEl && e.target.tagName === 'LI') {
+        const list = document.getElementById('memory-list');
+        list.insertBefore(dragSrcEl, e.target.nextSibling);
+    }
+ });
+
+ document.getElementById('memory-validate').addEventListener('click', () => {
+    const items = Array.from(document.querySelectorAll('#memory-list li')).map(li => li.textContent);
+    const correct = state.currentMemory.steps;
+    let correctCount = 0;
+    items.forEach((step, idx) => {
+        if (step === correct[idx]) correctCount++;
+    });
+    document.getElementById('memory-feedback').textContent = `${correctCount}/${correct.length} passos corretos.`;
+ });
+
+ document.getElementById('memory-show').addEventListener('click', () => {
+    document.getElementById('memory-feedback').textContent = state.currentMemory.steps.join('\n');
+ });
+
+// Database view
+ function populateDatabase() {
+    const list = document.getElementById('db-list');
+    const filter = document.getElementById('filter-tag');
+    function render() {
+        const tag = filter.value.trim().toLowerCase();
+        list.innerHTML = '';
+        const all = [...state.data.flash, ...state.data.memory];
+        all.filter(item => !tag || (item.tags && item.tags.some(t => t.toLowerCase().includes(tag)))).forEach(item => {
+            const li = document.createElement('li');
+            li.textContent = item.front || item.title;
+            list.appendChild(li);
+        });
+    }
+    filter.addEventListener('input', render);
+    render();
+ }
+
+loadData();

--- a/data/hawker400.json
+++ b/data/hawker400.json
@@ -1,0 +1,331 @@
+{
+  "flash": [
+    {"id":"fc-what-is-vmcg-flaps-0-10-and-20","front":"What is VMCG (Flaps 0°, 10° and 20°)?","back":"88 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"9-10"}},
+    {"id":"fc-what-is-vmca-flaps-0","front":"What is VMCA (Flaps 0°)?","back":"96 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"11-12"}},
+    {"id":"fc-what-is-vmca-flaps-10-and-20","front":"What is VMCA (Flaps 10° and 20°)?","back":"89 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"13-14"}},
+    {"id":"fc-what-is-vmo-sl-to-8000-ft","front":"What is VMO (S.L. to 8,000 ft)?","back":"264 KIAS","tags":["limitations","altitudes","speeds"],"source":{"file":"FlashCards1.pdf","pages":"15-16"}},
+    {"id":"fc-what-is-vmo-8000-to-11000-ft","front":"What is VMO (8,000 to 11,000 ft)?","back":"264 to 320 KIAS Linear Variation Between Altitudes","tags":["limitations","altitudes","speeds"],"source":{"file":"FlashCards1.pdf","pages":"17-18"}},
+    {"id":"fc-what-is-vmo-11000-to-26000-ft","front":"What is VMO (11,000 to 26,000 ft)?","back":"320 KIAS","tags":["limitations","altitudes","speeds"],"source":{"file":"FlashCards1.pdf","pages":"19-20"}},
+    {"id":"fc-what-is-mmo-above-26000-ft","front":"What is MMO (above 26,000 ft)?","back":"0.78MI","tags":["limitations","altitudes"],"source":{"file":"FlashCards1.pdf","pages":"21-22"}},
+    {"id":"fc-what-is-vll-landing-light","front":"What is VLL (Landing Light)?","back":"200 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"23-24"}},
+    {"id":"fc-what-is-vww-windshield-wiper","front":"What is VWW (Windshield Wiper)?","back":"200 KIAS","tags":["limitations","weather","speeds"],"source":{"file":"FlashCards1.pdf","pages":"25-26"}},
+    {"id":"fc-what-is-the-maximum-tailwind-component-for-start","front":"What is the maximum tailwind component for start?","back":"No Limit","tags":["limitations","weather"],"source":{"file":"FlashCards1.pdf","pages":"29-30"}},
+    {"id":"fc-what-is-the-maximum-zero-fuel-weight","front":"What is the MAXIMUM Zero Fuel Weight?","back":"13,000 lbs","tags":["limitations","weights"],"source":{"file":"FlashCards1.pdf","pages":"31-32"}},
+    {"id":"fc-what-is-the-maximum-landing-weight","front":"What is the MAXIMUM Landing Weight?","back":"15,700 lbs • NOTE: Inspection required with landings over 15,700 lbs","tags":["limitations","weights"],"source":{"file":"FlashCards1.pdf","pages":"33-34"}},
+    {"id":"fc-what-is-the-maximum-takeoff-weight","front":"What is the MAXIMUM Takeoff Weight?","back":"16,100 lbs 16,300 lbs with Kit (P/N 128-5052)","tags":["limitations","weights"],"source":{"file":"FlashCards1.pdf","pages":"35-36"}},
+    {"id":"fc-what-is-the-maximum-ramp-weight","front":"What is the MAXIMUM Ramp Weight?","back":"16,300 lbs 16,500 lbs with Kit (P/N 128-5052)","tags":["limitations","weights"],"source":{"file":"FlashCards1.pdf","pages":"37-38"}},
+    {"id":"fc-what-is-the-maximum-operating-altitude","front":"What is the Maximum Operating Altitude?","back":"45,000 ft","tags":["limitations","altitudes"],"source":{"file":"FlashCards1.pdf","pages":"45-46"}},
+    {"id":"fc-what-is-the-minimum-required-flight-crew","front":"What is the minimum required flight crew?","back":"1 Pilot & 1 Co-pilot","tags":["limitations","crew","documentation"],"source":{"file":"FlashCards1.pdf","pages":"53-54"}},
+    {"id":"fc-what-are-the-authorized-kinds-of-operations","front":"What are the authorized kinds of operations?","back":"• Day • Night • VFR • IFR • Known icing conditions","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"55-56"}},
+    {"id":"fc-what-are-the-3-main-sources-of-dc-power","front":"What are the 3 Main Sources of DC power?","back":"1. 1 Lead-Acid Battery (24 VDC/40 Amps) 2. 2 Generators (28 VDC/400 Amps) 3. 1 GPU (28 VDC/1000-1500 Amps)","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"69-70"}},
+    {"id":"fc-what-are-the-sources-of-ac-power","front":"What are the sources of AC power?","back":"Two inverters, each producing 26 VAC and 115 VAC","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"71-72"}},
+    {"id":"fc-what-is-the-maximum-altitude-for-landing-light-ext","front":"What is the maximum altitude for landing light extension?","back":"20,000 ft","tags":["limitations","altitudes"],"source":{"file":"FlashCards1.pdf","pages":"97-98"}},
+    {"id":"fc-what-is-normal-fire-bottle-pressure","front":"What is Normal Fire Bottle Pressure?","back":"FIRE PROTECTION 580 to 600 PSI","tags":["limitations","fire-protection"],"source":{"file":"FlashCards1.pdf","pages":"101-102"}},
+    {"id":"fc-what-is-vfe-vfo-for-flaps-10-and-20","front":"What is VFE /VFO for Flaps 10° and 20°?","back":"FLIGHT CONTROLS 200 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"107-108"}},
+    {"id":"fc-what-is-vfe-vfo-for-flaps-30","front":"What is VFE /VFO for Flaps 30°?","back":"FLIGHT CONTROLS VFE = 165 KIAS VFO = 170 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"109-110"}},
+    {"id":"fc-what-is-the-maximum-altitude-for-flap-extension","front":"What is the maximum altitude for flap extension?","back":"FLIGHT CONTROLS 20,000 ft","tags":["limitations","altitudes"],"source":{"file":"FlashCards1.pdf","pages":"111-112"}},
+    {"id":"fc-what-is-vsbmsb-for-speed-brakes","front":"What is VSB/MSB for Speed Brakes?","back":"FLIGHT CONTROLS No Limit","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"113-114"}},
+    {"id":"fc-what-are-the-max-usable-fuel-quantities","front":"What are the max usable fuel quantities?","back":"FUEL Wings - 2,862# Left Main Fuselage Right Main Fuselage - 2,050# 1,431# 2,050# 1,431# 213.6 Gallons 305.8 Gallons 213.6 Gallons Full - 4,912#","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"123-124"}},
+    {"id":"fc-what-is-the-maximum-fuel-unbalance-for-takeoff","front":"What is the Maximum Fuel Unbalance for takeoff?","back":"FUEL 100 lbs","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"129-130"}},
+    {"id":"fc-what-are-the-fuel-temperature-limits","front":"What are the fuel temperature limits?","back":"FUEL -40°C to 50°C","tags":["limitations","temperatures"],"source":{"file":"FlashCards1.pdf","pages":"133-134"}},
+    {"id":"fc-what-restrictions-apply-to-the-fuel-crossfeed-proc","front":"What restrictions apply to the fuel crossfeed process?","back":"FUEL • Crossfeed w/both engines operating is limited to level flight when less than 600# remains in the tank supplying fuel • Must be selected “NORM” for Takeoff and Landing","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"143-144"}},
+    {"id":"fc-what-is-maximum-hydraulic-system-pressure","front":"What is Maximum Hydraulic System Pressure?","back":"HYDRAULICS Red Line (1,850 PSI)","tags":["limitations","fire-protection"],"source":{"file":"FlashCards1.pdf","pages":"147-148"}},
+    {"id":"fc-what-is-the-required-type-of-hydraulic-fluid","front":"What is the required type of hydraulic fluid?","back":"HYDRAULICS MIL-H-5606","tags":["limitations","documentation"],"source":{"file":"FlashCards1.pdf","pages":"153-154"}},
+    {"id":"fc-what-is-vww-windshield-wiper-if-installed","front":"What is VWW (Windshield Wiper), if installed?","back":"ICE AND RAIN 200 KIAS","tags":["limitations","weather","speeds"],"source":{"file":"FlashCards1.pdf","pages":"157-158"}},
+    {"id":"fc-what-limitations-apply-to-windshield-antiice","front":"What limitations apply to windshield anti-ice?","back":"ICE AND RAIN • Must be on (LOW or HIGH) for all in-flight operations • HI mode is prohibited for takeoff and landing","tags":["limitations","weather"],"source":{"file":"FlashCards1.pdf","pages":"167-168"}},
+    {"id":"fc-what-is-maximum-tire-speed-vtire-","front":"What is Maximum Tire Speed (VTIRE )?","back":"LANDING GEAR & BRAKES 165 Kts Ground Speed","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"187-188"}},
+    {"id":"fc-what-is-the-maximum-altitude-for-gear-extension","front":"What is the maximum altitude for gear extension?","back":"LANDING GEAR & BRAKES 20,000 ft","tags":["limitations","altitudes"],"source":{"file":"FlashCards1.pdf","pages":"189-190"}},
+    {"id":"fc-what-is-the-maximum-pressure-differential","front":"What is the Maximum Pressure Differential?","back":"ENVIRONMENTAL 9.1 PSID","tags":["limitations","fire-protection"],"source":{"file":"FlashCards1.pdf","pages":"199-200"}},
+    {"id":"fc-what-engine-is-installed-on-the-beechjet-400a","front":"What engine is installed on the Beechjet 400A?","back":"POWERPLANT Pratt & Whitney JT15D-5, Or Pratt & Whitney JT15D-5R","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"213-214"}},
+    {"id":"fc-what-is-the-maximum-fan-speed-n1","front":"What is the maximum fan speed (N1)?","back":"POWERPLANT Red Line (104%)","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"217-218"}},
+    {"id":"fc-what-is-the-maximum-turbine-speed-n2","front":"What is the maximum turbine speed (N2)?","back":"POWERPLANT Red Line (96%)","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"219-220"}},
+    {"id":"fc-what-is-the-maximum-itt-for-starting","front":"What is the maximum ITT for starting?","back":"POWERPLANT • 550-600°C for 4 seconds maximum • 600-700°C for 2 seconds maximum • (See JT15D-5 maintenance manual if the above limitations are exceeded)","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"227-228"}},
+    {"id":"fc-what-is-the-maximum-itt-for-takeoff","front":"What is the maximum ITT for takeoff?","back":"POWERPLANT Red Line (700°C) (Limited to 5 minutes for both engines operating or 10 minutes for one engine)","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"229-230"}},
+    {"id":"fc-what-is-the-maximum-oil-pressure","front":"What is the maximum oil pressure?","back":"POWERPLANT Red Line (83 PSI)","tags":["limitations","fire-protection"],"source":{"file":"FlashCards1.pdf","pages":"233-234"}},
+    {"id":"fc-what-is-the-minimum-oil-temperature-for-starting","front":"What is the minimum oil temperature for starting?","back":"POWERPLANT Bottom of the yellow arc (-40°C)","tags":["limitations","temperatures"],"source":{"file":"FlashCards1.pdf","pages":"237-238"}},
+    {"id":"fc-what-is-the-maximum-oil-temperature","front":"What is the maximum oil temperature?","back":"POWERPLANT Red Line (121°C)","tags":["limitations","temperatures"],"source":{"file":"FlashCards1.pdf","pages":"243-244"}},
+    {"id":"fc-what-is-maximum-continuous-itt","front":"What is maximum continuous ITT?","back":"POWERPLANT Top of the green arc (680°C)","tags":["limitations"],"source":{"file":"FlashCards1.pdf","pages":"245-246"}},
+    {"id":"fc-what-is-the-minimum-speed-for-using-full-reverse-t","front":"What is the minimum speed for using full reverse thrust?","back":"POWERPLANT 55 KIAS","tags":["limitations","speeds"],"source":{"file":"FlashCards1.pdf","pages":"249-250"}}
+  ],
+  "memory": [
+    {
+      "id": "mem-engine-failure-during-takeoff-below-v1-takeoff-abo",
+      "title": "ENGINE FAILURE DURING TAKEOFF (BELOW V1 - TAKEOFF ABORTED)",
+      "steps": [
+        "Brakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . Apply",
+        "Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IDLE",
+        "Thrust Reverser(s) . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .DEPLOY",
+        "Reverser Lights . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . VERIFY",
+        "Reverse Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . AS REQUIRED",
+        "Speed Brakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .EXTEND"
+      ],
+      "distractors": [],
+      "tags": ["engine","takeoff","failure"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "261-262"}
+    },
+    {
+      "id": "mem-engine-failure-during-takeoff-above-v1-takeoff-con",
+      "title": "ENGINE FAILURE DURING TAKEOFF (ABOVE V1 - TAKEOFF CONTINUED)",
+      "steps": [
+        "Nose Up Pitch Attitude at Rotation (VR) 13º to 15º Desired",
+        "Landing Gear . . . . . . . . . . . . . . UP, when positive rate-of-climb is established",
+        "Airspeed . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . MAINTAIN V2"
+      ],
+      "distractors": [],
+      "tags": ["engine","takeoff","failure"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "263-264"}
+    },
+    {
+      "id": "mem-engine-fire",
+      "title": "ENGINE FIRE",
+      "steps": [
+        "Thrust (affected engine) . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IDLE If ENG FIRE PUSH switch light remains illuminated:",
+        "Thrust Lever (affected engine) . . . . . . . . . . . . . . . . . . . . . .CUTOFF",
+        "Illuminated Engine Fire Switch . . . . . . . . . . . . . . . . . . . . . . . . PUSH",
+        "Either Fire Bottle Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . PUSH"
+      ],
+      "distractors": [],
+      "tags": ["engine","fire"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "265-266"}
+    },
+    {
+      "id": "mem-engine-fire-detector-failure",
+      "title": "ENGINE FIRE DETECTOR FAILURE",
+      "steps": [
+        "If the FIRE DET FAIL annunciator illuminates follow an ENG FIRE PUSH switch illumination the fire shoud be considered to still be burning",
+        "Engine Fire Procedure . . . . . . . . . . . . . . . . . COMPLETE",
+        "Remaining Illuminated Fire Bottle Swithch . . . . . . . . . . . . . . . . . . . . . . . . . PUSH"
+      ],
+      "distractors": [],
+      "tags": ["engine","fire","failure"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "267-268"}
+    },
+    {
+      "id": "mem-engine-failure-in-landing-configuration",
+      "title": "ENGINE FAILURE IN LANDING CONFIGURATION",
+      "steps": [
+        "Thrust (operative engine) . . . . . . . . . . . . . . . . . . . . . . . AS REQUIRED",
+        "Airspeed . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .VREF (MINIMUM)"
+      ],
+      "distractors": [],
+      "tags": ["engine","landing","failure"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "269-270"}
+    },
+    {
+      "id": "mem-inadvertent-thrust-reverser-deployment-during-take",
+      "title": "INADVERTENT THRUST REVERSER DEPLOYMENT DURING TAKEOFF (BELOW V1 - TAKEOFF ABORTED)",
+      "steps": [
+        "Brakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . APPLY",
+        "Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IDLE",
+        "Thrust Reversers . . . . . . . . . . . . . . . . . . . . . . . . . . BOTH DEPLOY",
+        "Reverser Lights . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . VERIFY",
+        "Reverse Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . AS REQUIRED",
+        "Speed Brakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . EXTEND"
+      ],
+      "distractors": [],
+      "tags": ["takeoff"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "271-272"}
+    },
+    {
+      "id": "mem-inadvertent-thrust-reverser-deployment-during-take-1",
+      "title": "INADVERTENT THRUST REVERSER DEPLOYMENT DURING TAKEOFF (ABOVE V1 - TAKEOFF CONTINUED)",
+      "steps": [
+        "Emergency Stow Push-Switch(affected engine) . . . . . . . . . . . . . . PUSH",
+        "Nose Up Pitch Attitude atRotation . . . . . . . . . . . . . . . . 13-15° DESIRED",
+        "Landing Gear(when positive climb established) . . . . . . . . . . . . . . . . . . . . UP",
+        "Airspeed . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . V2 (MIN) If reverser will not stow and lock:",
+        "Thrust Lever (affected engine) . . . . . . . . . . . . . . . . . . . . . . . . .CUTOFF"
+      ],
+      "distractors": [],
+      "tags": ["takeoff"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "273-274"}
+    },
+    {
+      "id": "mem-inadvertent-thrust-reverser-deployment-in-flight",
+      "title": "INADVERTENT THRUST REVERSER DEPLOYMENT IN FLIGHT",
+      "steps": [
+        "Emergency Stow Push-Switch (affected engine) . . . . . . . . . . . . . . PUSH",
+        "Altitude . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . BELOW 30,000 ft",
+        "Airspeed (until reverser stows/locks) . . . . . . . . . . . . . . . . BELOW 135 KIAS"
+      ],
+      "distractors": [],
+      "tags": ["general"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "275-276"}
+    },
+    {
+      "id": "mem-inadvertent-overspeed",
+      "title": "INADVERTENT OVERSPEED",
+      "steps": [
+        "Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IDLE",
+        "Speedbrakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .EXTEND",
+        "If airplane is in a nose-down attitude, initiate a wings-level pull-up with exceeding structural limits (3.2g)"
+      ],
+      "distractors": [],
+      "tags": ["overspeed"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "277-278"}
+    },
+    {
+      "id": "mem-electrical-fire-or-smoke",
+      "title": "ELECTRICAL FIRE OR SMOKE",
+      "steps": [
+        "Oxygen Masks . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Smoke Goggles . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Mic Selector . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OXY MASK",
+        "SPKR Switches . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ON or DON HEADSET",
+        "INTPH Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ON",
+        "Smoke Removal Procedures . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IF NECESSARY If known source:",
+        "Faulted Circuits . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ISOLATE If unknown source:",
+        "Battery . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . EMER",
+        "Master Generator Switches . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . EMER"
+      ],
+      "distractors": [],
+      "tags": ["fire","electrical","smoke"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "279-280"}
+    },
+    {
+      "id": "mem-environmental-system-smoke-or-odor",
+      "title": "ENVIRONMENTAL SYSTEM SMOKE OR ODOR",
+      "steps": [
+        "Oxygen Masks . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Smoke Goggles . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Mic Selectors . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OXY MASK",
+        "SPKR Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . .ON or DON HEADSET",
+        "INTPH Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ON",
+        "Cabin Pressure Source . . . . . . . . . . . . . . . . . . . . . . . . ISOLATE SOURCE"
+      ],
+      "distractors": [],
+      "tags": ["smoke"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "281-282"}
+    },
+    {
+      "id": "mem-smoke-removal",
+      "title": "SMOKE REMOVAL",
+      "steps": [
+        "Oxygen Masks . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Smoke Goggles . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Mic Selectors . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OXY MASK",
+        "SPKR Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . .ON or DON HEADSET",
+        "INTPH Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ON"
+      ],
+      "distractors": [],
+      "tags": ["smoke"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "283-284"}
+    },
+    {
+      "id": "mem-cabin-decompression",
+      "title": "CABIN DECOMPRESSION",
+      "steps": [
+        "Oxygen Masks . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Mic Selectors . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OXY MASK",
+        "SPKR Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . .ON or DON HEADSET",
+        "INTPH Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ON"
+      ],
+      "distractors": [],
+      "tags": ["pressurization"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "285-286"}
+    },
+    {
+      "id": "mem-emergency-descent",
+      "title": "EMERGENCY DESCENT",
+      "steps": [
+        "Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IDLE",
+        "Speedbrakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . EXT",
+        "Autopilot . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OFF",
+        "Initiate Moderate Bank . . . . . . . . . . . . . . . . . . . . . . . . . . .45° MAX"
+      ],
+      "distractors": [],
+      "tags": ["emergency","descent"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "287-288"}
+    },
+    {
+      "id": "mem-over-pressurization",
+      "title": "OVER PRESSURIZATION",
+      "steps": [
+        "Cabin Pressure Source . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OFF",
+        "Oxygen Masks . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DON",
+        "Mic Selectors . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . OXY MASK",
+        "SPKR Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . .ON or DON HEADSET",
+        "INTPH Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ON"
+      ],
+      "distractors": [],
+      "tags": ["general"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "289-290"}
+    },
+    {
+      "id": "mem-loss-of-both-generators",
+      "title": "LOSS OF BOTH GENERATORS",
+      "steps": [
+        "GEN FLD and START/GEN Circuit Breakers",
+        "Generator Reset (L and R) . . . . . . . . . . . . . . . . . . . . RESET/NORM"
+      ],
+      "distractors": [],
+      "tags": ["electrical"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "291-292"}
+    },
+    {
+      "id": "mem-pitch-roll-rudder-trim-runaway-or-failure",
+      "title": "PITCH / ROLL / RUDDER TRIM RUNAWAY OR FAILURE",
+      "steps": [
+        "TRIM INT/AP Disengage Switch . . . . . . . . . . . . . . . . . . PUSH AND HOLD"
+      ],
+      "distractors": [],
+      "tags": ["failure","trim"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "293-294"}
+    },
+    {
+      "id": "mem-power-brake-failure",
+      "title": "POWER BRAKE FAILURE",
+      "steps": [
+        "Break Safety Wire and Remove Guard Clip on Emergency Brake Handle",
+        "Emergency Brakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . APPLY GRADUALLY"
+      ],
+      "distractors": [],
+      "tags": ["failure","brakes"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "295-296"}
+    },
+    {
+      "id": "mem-autopilot-trim-fail",
+      "title": "AUTOPILOT TRIM FAIL",
+      "steps": [
+        "Trim Indicators CHECK FOR PROPER POSITION FOR FLIGHT CONDITION",
+        "TRIM INT/AP Disengage Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . PUSH"
+      ],
+      "distractors": [],
+      "tags": ["trim","autopilot"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "297-298"}
+    },
+    {
+      "id": "mem-autopilot-overspeed-recovery",
+      "title": "AUTOPILOT OVERSPEED RECOVERY",
+      "steps": [
+        "Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . IDLE"
+      ],
+      "distractors": [],
+      "tags": ["overspeed","autopilot"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "299-300"}
+    },
+    {
+      "id": "mem-flight-director-malfunctions",
+      "title": "FLIGHT DIRECTOR MALFUNCTIONS",
+      "steps": [
+        "TRIM INT/AP Disengage Switch . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . PUSH"
+      ],
+      "distractors": [],
+      "tags": ["general"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "301-302"}
+    },
+    {
+      "id": "mem-loss-of-airspeed-indications",
+      "title": "LOSS OF AIRSPEED INDICATION(S)",
+      "steps": [
+        "Autopilot . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . DISCONNECT",
+        "Airspeed . . . . . . . . . . . . . . . . . . . . . . . . . SLOW TO 0.2 AOA and MAINTAIN",
+        "Thrust . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . AS REQUIRED",
+        "Speedbrakes . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . AS REQUIRED (Slow to 0.25 AOA with the speedbrakes extended)"
+      ],
+      "distractors": [],
+      "tags": ["airspeed"],
+      "source": {"file": "FlashCardsMEMORYITENS.pdf","pages": "303-304"}
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Hawker 400 Trainer</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header>
+        <h1>Hawker 400 Trainer</h1>
+        <p class="disclaimer">Material didático. Não substitui AFM/POH/QRH, nem treinamento aprovado.</p>
+    </header>
+
+    <nav>
+        <button data-tab="duel">Duelo</button>
+        <button data-tab="train" class="active">Treino</button>
+        <button data-tab="database">Banco de Dados</button>
+        <button data-tab="config">Config</button>
+    </nav>
+
+    <main>
+        <section id="duel" class="tab hidden">
+            <p>Duelo online/pass-and-play ainda não implementado.</p>
+        </section>
+
+        <section id="train" class="tab">
+            <div class="mode-select">
+                <button id="start-flash">Flash Cards</button>
+                <button id="start-memory">Memory Items</button>
+            </div>
+
+            <div id="flash-area" class="hidden">
+                <div id="flash-question" class="card"></div>
+                <input id="flash-answer" type="text" placeholder="Resposta">
+                <button id="flash-submit">Responder</button>
+                <button id="flash-reveal">Revelar</button>
+                <div id="flash-feedback"></div>
+            </div>
+
+            <div id="memory-area" class="hidden">
+                <h2 id="memory-title"></h2>
+                <ul id="memory-list" class="draggable-list"></ul>
+                <button id="memory-validate">Validar</button>
+                <button id="memory-show">Mostrar sequência oficial</button>
+                <div id="memory-feedback"></div>
+            </div>
+        </section>
+
+        <section id="database" class="tab hidden">
+            <h2>Banco de Dados</h2>
+            <input type="text" id="filter-tag" placeholder="Filtrar por tag">
+            <ul id="db-list"></ul>
+        </section>
+
+        <section id="config" class="tab hidden">
+            <h2>Configurações</h2>
+            <label>Tempo por pergunta (s): <input type="number" id="cfg-time" min="5" max="60"></label>
+            <label>Tolerância numérica (kt): <input type="number" id="cfg-tolerance" min="0" max="10"></label>
+            <button id="cfg-save">Salvar</button>
+        </section>
+    </main>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,65 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header {
+    background: #222;
+    color: #fff;
+    padding: 1rem;
+    text-align: center;
+}
+
+nav {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    background: #eee;
+    padding: 0.5rem;
+}
+
+nav button {
+    padding: 0.5rem 1rem;
+    border: none;
+    background: #ccc;
+    cursor: pointer;
+}
+
+nav button.active {
+    background: #888;
+    color: #fff;
+}
+
+.tab {
+    padding: 1rem;
+}
+
+.hidden {
+    display: none;
+}
+
+.card {
+    font-size: 1.2rem;
+    margin-bottom: 0.5rem;
+}
+
+.disclaimer {
+    font-size: 0.8rem;
+}
+
+.draggable-list {
+    list-style: none;
+    padding: 0;
+}
+
+.draggable-list li {
+    padding: 0.5rem;
+    margin: 0.25rem 0;
+    background: #f2f2f2;
+    border: 1px solid #ccc;
+    cursor: grab;
+}


### PR DESCRIPTION
## Summary
- add static Hawker 400 Trainer prototype with tabs for training and config
- implement flash card checking with unit normalization and tolerance
- add memory item drag-and-drop with simple validation
- provide dataset of limitations and memory items for the aircraft

## Testing
- `python -m json.tool data/hawker400.json`
- `node --check app.js`
- `node -e "const d=require('./data/hawker400.json'); console.log('flash',d.flash.length,'memory',d.memory.length);"`


------
https://chatgpt.com/codex/tasks/task_e_689b83e853b4832f93a892f4842a4fb0